### PR TITLE
Bump MW to 1.34

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -7,10 +7,11 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "specialpage",
 	"requires": {
-		"MediaWiki": ">= 1.32.0",
+		"MediaWiki": ">= 1.34.0",
 		"extensions": {
-			"Sanctions": "*",
-			"Flow": "*"
+			"Echo": "*",
+			"Flow": "*",
+			"RenameUser": "*"
 		}
 	},
 	"AvailableRights": [ "sanctions-execute" ],

--- a/maintenance/SanctionsCreateTemplates.php
+++ b/maintenance/SanctionsCreateTemplates.php
@@ -25,8 +25,8 @@ class SanctionsCreateTemplates extends LoggedUpdateMaintenance {
 		return [
 			'sanctions-agree-template-title' => function ( Title $title ) {
 				// get "User:" namespace prefix in wiki language
-				global $wgContLang;
-				$namespaces = $wgContLang->getFormattedNamespaces();
+				$contLang = \MediaWiki\MediaWikiServices::getInstance()->getContentLanguage();
+				$namespaces = $contLang->getFormattedNamespaces();
 
 				// @codingStandardsIgnoreLine
 				return "[[" . $namespaces[NS_FILE] . ":Symbol support vote.svg|17px]]" .
@@ -41,8 +41,8 @@ class SanctionsCreateTemplates extends LoggedUpdateMaintenance {
 			},
 			'sanctions-disagree-template-title' => function ( Title $title ) {
 				// get "User:" namespace prefix in wiki language
-				global $wgContLang;
-				$namespaces = $wgContLang->getFormattedNamespaces();
+				$contLang = \MediaWiki\MediaWikiServices::getInstance()->getContentLanguage();
+				$namespaces = $contLang->getFormattedNamespaces();
 
 				return "[[" . $namespaces[NS_FILE] . ":Symbol oppose vote.svg|17px]]" .
 				"<span class=\"sanction-vote-disagree\"></span>'''" .


### PR DESCRIPTION
- Bump MW to REL1_34
- Avoid usage of deprecated $wgContLang global (dep in 1.32)