### PR TITLE
BaseTemplateToolbox hook is deprecated

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -101,7 +101,7 @@
 		"UserToolLinksEdit": "SanctionsHooks::onUserToolLinksEdit",
 		"DiffRevisionTools": "SanctionsHooks::onDiffRevisionTools",
 		"HistoryRevisionTools": "SanctionsHooks::onHistoryRevisionTools",
-		"BaseTemplateToolbox": "SanctionsHooks::onBaseTemplateToolbox",
+		"SidebarBeforeOutput": "SanctionsHooks::onSidebarBeforeOutput",
 		"ContributionsToolLinks": "SanctionsHooks::onContributionsToolLinks",
 		"FlowAddModules": "SanctionsHooks::onFlowAddModules"
 	},

--- a/includes/SanctionsHooks.php
+++ b/includes/SanctionsHooks.php
@@ -243,7 +243,7 @@ class SanctionsHooks {
 		$user = $skin->getRelevantUser();
 
 		if ( !$user ) {
-		   return;
+			return;
 		}
 
 		$rootUser = $user->getName();

--- a/includes/SanctionsHooks.php
+++ b/includes/SanctionsHooks.php
@@ -248,8 +248,8 @@ class SanctionsHooks {
 
 		$rootUser = $user->getName();
 
-		$sanctionsLink = [ 
-			'sanctions' => [ 
+		$sanctionsLink = [
+			'sanctions' => [
 				'text' => $skin->msg( 'sanctions-link-on-user-page' )->text(),
 				'href' => $skin::makeSpecialUrlSubpage( 'Sanctions', $rootUser ),
 				'id' => 't-sanctions'

--- a/includes/SanctionsHooks.php
+++ b/includes/SanctionsHooks.php
@@ -236,24 +236,32 @@ class SanctionsHooks {
 	}
 
 	/**
-	 * @param BaseTemplate $baseTemplate The BaseTemplate base skin template.
-	 * @param array &$toolbox An array of toolbox items.
+	 * @param Skin $skin Skin object
+	 * @param array[] &$Sidebar An array of arrays of sidebar items.
 	 */
-	public static function onBaseTemplateToolbox( BaseTemplate $baseTemplate, array &$toolbox ) {
-		$user = $baseTemplate->getSkin()->getRelevantUser();
-		if ( $user ) {
-			$rootUser = $user->getName();
+	public static function onSidebarBeforeOutput( Skin $skin, array &$sidebar ) {
+		$user = $skin->getRelevantUser();
 
-			$toolbox = wfArrayInsertAfter(
-				$toolbox,
-				[ 'sanctions' => [
-					'text' => wfMessage( 'sanctions-link-on-user-page' )->text(),
-					'href' => Skin::makeSpecialUrlSubpage( 'Sanctions', $rootUser ),
-					'id' => 't-sanctions'
-				] ],
-				isset( $toolbox['blockip'] ) ? 'blockip' : 'log'
-			);
+		if ( !$user ) {
+		   return;
 		}
+
+		$rootUser = $user->getName();
+
+		$sanctionsLink = [ 
+			'sanctions' => [ 
+				'text' => $skin->msg( 'sanctions-link-on-user-page' )->text(),
+				'href' => $skin::makeSpecialUrlSubpage( 'Sanctions', $rootUser ),
+				'id' => 't-sanctions'
+			]
+		];
+
+		$toolbox = $sidebar['TOOLBOX'];
+		$sidebar['TOOLBOX'] = wfArrayInsertAfter(
+			$toolbox,
+			$sanctionsLink,
+			isset( $toolbox['blockip'] ) ? 'blockip' : 'log'
+		);
 	}
 
 	/**

--- a/includes/SanctionsHooks.php
+++ b/includes/SanctionsHooks.php
@@ -237,7 +237,7 @@ class SanctionsHooks {
 
 	/**
 	 * @param Skin $skin Skin object
-	 * @param array[] &$Sidebar An array of arrays of sidebar items.
+	 * @param array[] &$sidebar An array of arrays of sidebar items.
 	 */
 	public static function onSidebarBeforeOutput( Skin $skin, array &$sidebar ) {
 		$user = $skin->getRelevantUser();

--- a/includes/SanctionsHooks.php
+++ b/includes/SanctionsHooks.php
@@ -259,8 +259,9 @@ class SanctionsHooks {
 		if ( !isset( $sidebar['TOOLBOX'] ) ) {
 			$sidebar['TOOLBOX'] = [];
 		}
+
 		$toolbox = $sidebar['TOOLBOX'];
-		
+
 		$sidebar['TOOLBOX'] = wfArrayInsertAfter(
 			$toolbox,
 			$sanctionsLink,

--- a/includes/SanctionsHooks.php
+++ b/includes/SanctionsHooks.php
@@ -256,7 +256,11 @@ class SanctionsHooks {
 			]
 		];
 
+		if ( !isset( $sidebar['TOOLBOX'] ) ) {
+			$sidebar['TOOLBOX'] = [];
+		}
 		$toolbox = $sidebar['TOOLBOX'];
+		
 		$sidebar['TOOLBOX'] = wfArrayInsertAfter(
 			$toolbox,
 			$sanctionsLink,


### PR DESCRIPTION
BaseTemplateToolbox hook will emit  deprecation notice in MW 1.35
https://phabricator.wikimedia.org/T253416